### PR TITLE
docs: clarify second review via LLM is sufficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ They are knowledgeable around large parts of the codebase, and work to balance u
 - Core Maintainers will have `Owner` access on the GitHub organisation
 - Core Maintainers will retain `Owner` access in perpetuity
 - Pull Requests created by Core Maintainers should be reviewed by another Maintainer/Core Maintainer, but this isn't required
+  - In the case that an automated code review service (such as one using Large Language Models (LLMs)) is employed for code review in the absence of a Core Maintainer's second review, this will be sufficient
 
 ## Sponsorship
 


### PR DESCRIPTION
For instance, right now, I've got a fair bit of "life happens" stuff. To
make this clear to our users that we're allowing a second review via
LLM, we can make it explicit in our Governance.
